### PR TITLE
rgl.viewpoint changed to view3d

### DIFF
--- a/R/blsm.R
+++ b/R/blsm.R
@@ -385,7 +385,7 @@ plot_latent_positions = function(blsm_obj, colors, points_size=0.1, labels_point
       
       rgl::plot3d(blsm_obj$Iterations[,1,],blsm_obj$Iterations[,2,],blsm_obj$Iterations[,3,], size=points_size*10, 
              col=colors, xlab = "", ylab="", zlab="")
-      rgl::rgl.viewpoint(theta=30, phi=10, fov=30)
+      rgl::view3d(theta=30, phi=10, fov=30)
       
       if (missing(avg_Z_est)){
         avg_Z_est=rowMeans(blsm_obj$Iterations, dims=2, na.rm = TRUE)


### PR DESCRIPTION
Some upcoming changes to the rgl package will require changes to
BLSM.  I will be deprecating a number of rgl.* function
calls. You can read about the issues here:

           https://dmurdoch.github.io/rgl/articles/deprecation.html

I have made the required changes to BLSM in the attached
patch. These changes should work with both old and new rgl 
versions.
